### PR TITLE
Mark the crate as no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/oberien/str-concat"
 description = "Concatenate two adjacent string slices"
 keywords = ["str", "concat", "concatenate", "string", "slice"]
+categories = ["no-std"]
 readme = "README.md"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-use std::{slice, str};
+#![no_std]
+use core::{slice, str};
 
 /// Error that can occur during [`concat`](fn.concat.html).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Increases the likelihood that someone from wg-unsafe-code-guidelines has
a look at it, or that it is included in an embedded project where such
memory saving optimizations may have more relevance.