### PR TITLE
Add `concat_slice` and mark everything as unsafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,18 @@ use str_concat::{concat, concat_unordered, Error};
 fn main() {
     let s = "0123456789";
     // ordered, `a` before `b`
-    assert_eq!(Ok("0123456"), concat(&s[..5], &s[5..7]));
-    assert_eq!(Ok("0123456"), concat_unordered(&s[..5], &s[5..7]));
+    unsafe {
+        // SAFETY: the slices are from the same `&str`.
+        assert_eq!(Ok("0123456"), concat(&s[..5], &s[5..7]));
+        assert_eq!(Ok("0123456"), concat_unordered(&s[..5], &s[5..7]));
+    }
 
     // unordered, `b` before `a`
-    assert_eq!(Err(Error::NotAdjacent), concat(&s[5..7], &s[..5]));
-    assert_eq!(Ok("0123456"), concat_unordered(&s[5..7], &s[..5]));
+    unsafe {
+        // SAFETY: the slices are from the same `&str`.
+        assert_eq!(Err(Error::NotAdjacent), concat(&s[5..7], &s[..5]));
+        assert_eq!(Ok("0123456"), concat_unordered(&s[5..7], &s[..5]));
+    }
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,12 @@ pub enum Error {
 /// Returns `Err` if the two slices aren't adjacent, `a` is after `b`, or if
 /// `a` is too long for proper concatenation (longer than `isize::MAX`).
 ///
+/// # Safety
+///
+/// The provided slices must come from the same underlying allocation. The adjacency test can not
+/// reliably differentiate between the one-past-the-end pointer of one allocation and the start of
+/// another. However, all slices must be within a single allocation.
+///
 /// # Examples
 ///
 /// Correct usage:
@@ -27,7 +33,10 @@ pub enum Error {
 /// ```rust
 /// # use str_concat::concat;
 /// let s = "0123456789";
-/// assert_eq!("0123456", concat(&s[..5], &s[5..7]).unwrap());
+/// unsafe {
+///     // SAFETY: slices from the same str originally.
+///     assert_eq!("0123456", concat(&s[..5], &s[5..7]).unwrap());
+/// }
 /// ```
 ///
 /// Non-adjacent string slices:
@@ -35,24 +44,25 @@ pub enum Error {
 /// ```rust
 /// # use str_concat::{concat, Error};
 /// let s = "0123456789";
-/// assert_eq!(Err(Error::NotAdjacent), concat(&s[..5], &s[6..7]))
+/// unsafe {
+///     // SAFETY: slices from the same str originally.
+///     assert_eq!(Err(Error::NotAdjacent), concat(&s[..5], &s[6..7]))
+/// }
 /// ```
-pub fn concat<'a>(a: &'a str, b: &'a str) -> Result<&'a str, Error> {
+pub unsafe fn concat<'a>(a: &'a str, b: &'a str) -> Result<&'a str, Error> {
     let slice = concat_slice(a.as_bytes(), b.as_bytes())?;
 
-    unsafe {
-        // * concatenating two valid UTF8 strings will produce a valid UTF8 string
-        // * a BOM in `b` is still valid:
-        //   > It is important to understand that the character U+FEFF appearing at
-        //   > any position other than the beginning of a stream MUST be interpreted
-        //   > with the semantics for the zero-width non-breaking space, and MUST
-        //   > NOT be interpreted as a signature.
-        // * the grapheme *clusters* (and thus potentially the semantics of the string
-        //   might change if the first code point of `b` is a combining character,
-        //   a zero width joiner or similar.
-        //   This does not affect the correctness of UTF-8.
-        Ok(str::from_utf8_unchecked(slice))
-    }
+    // * concatenating two valid UTF8 strings will produce a valid UTF8 string
+    // * a BOM in `b` is still valid:
+    //   > It is important to understand that the character U+FEFF appearing at
+    //   > any position other than the beginning of a stream MUST be interpreted
+    //   > with the semantics for the zero-width non-breaking space, and MUST
+    //   > NOT be interpreted as a signature.
+    // * the grapheme *clusters* (and thus potentially the semantics of the string
+    //   might change if the first code point of `b` is a combining character,
+    //   a zero width joiner or similar.
+    //   This does not affect the correctness of UTF-8.
+    Ok(str::from_utf8_unchecked(slice))
 }
 
 /// Concatenate two slices if they are adjacent.
@@ -71,6 +81,12 @@ pub fn concat<'a>(a: &'a str, b: &'a str) -> Result<&'a str, Error> {
 /// When T is a ZST then returns `Err(TooLong)` if the total length would overflow
 /// `usize` and `Err(NotAdjacent)` otherwise.
 ///
+/// # Safety
+///
+/// The provided slices must come from the same underlying allocation. The adjacency test can not
+/// reliably differentiate between the one-past-the-end pointer of one allocation and the start of
+/// another. However, all slices must be within a single allocation.
+///
 /// # Examples
 ///
 /// Correct usage:
@@ -78,7 +94,10 @@ pub fn concat<'a>(a: &'a str, b: &'a str) -> Result<&'a str, Error> {
 /// ```rust
 /// # use str_concat::concat_slice;
 /// let s = b"0123456789";
-/// assert_eq!(b"0123456", concat_slice(&s[..5], &s[5..7]).unwrap());
+/// unsafe {
+///     // SAFETY: slices from the same bytes originally.
+///     assert_eq!(b"0123456", concat_slice(&s[..5], &s[5..7]).unwrap());
+/// }
 /// ```
 ///
 /// Non-adjacent byte slices:
@@ -86,10 +105,13 @@ pub fn concat<'a>(a: &'a str, b: &'a str) -> Result<&'a str, Error> {
 /// ```rust
 /// # use str_concat::{concat_slice, Error};
 /// let s = b"0123456789";
-/// assert_eq!(Err(Error::NotAdjacent), concat_slice(&s[..5], &s[6..7]))
+/// unsafe {
+///     // SAFETY: slices from the same bytes originally.
+///     assert_eq!(Err(Error::NotAdjacent), concat_slice(&s[..5], &s[6..7]))
+/// }
 /// ```
 ///
-pub fn concat_slice<'a, T>(a: &'a [T], b: &'a [T]) -> Result<&'a [T], Error> {
+pub unsafe fn concat_slice<'a, T>(a: &'a [T], b: &'a [T]) -> Result<&'a [T], Error> {
     let a_ptr = a.as_ptr();
     let b_ptr = b.as_ptr();
 
@@ -114,40 +136,44 @@ pub fn concat_slice<'a, T>(a: &'a [T], b: &'a [T]) -> Result<&'a [T], Error> {
     assert!(a_len <= max_len as usize);
     assert!(b_len <= max_len as usize);
 
-    unsafe {
-        // https://doc.rust-lang.org/std/primitive.pointer.html#safety-1
-        // * starting pointer in-bounds obviously
-        // * ending pointer one byte past the end of an allocated object
-        // * explicit isize overflow check above
-        // * no wraparound required
-        // why: this is the one byte past the end pointer for the input slice `a`
-        if a_ptr.offset(a_len as isize) != b_ptr {
-            return Err(Error::NotAdjacent);
-        }
-        // UNWRAP: both smaller than isize, can't wrap in usize.
-        // This is because in rust `usize` and `isize` are both guaranteed to have
-        // the same number of bits as a pointer [1]. As `isize` is signed, a `usize`
-        // can always store the sum of two positive `isize`.
-        // [1]: https://doc.rust-lang.org/reference/types/numeric.html#machine-dependent-integer-types
-        let new_len = a_len.checked_add(b_len).unwrap();
-        // Ensure the length is bounded. The bound is strict from the definition of `max_len`
-        // `new_len <= max_len` <=> `new_len * mem::size_of::<T>() <= isize::max_value()`
-        if !(new_len <= max_len) {
-            return Err(Error::TooLong);
-        }
-        // https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#safety
-        // * slices are adjacent (checked above)
-        // * no double-free / leak because we work on borrowed data
-        // * no use-after-free because `a` and `b` have same lifetime
-        // * the total size is smaller than `isize::MAX` bytes, as max_len is rounded down
-        Ok(slice::from_raw_parts(a_ptr, new_len))
+    // https://doc.rust-lang.org/std/primitive.pointer.html#safety-1
+    // * starting pointer in-bounds obviously
+    // * ending pointer one byte past the end of an allocated object
+    // * explicit isize overflow check above
+    // * no wraparound required
+    // why: this is the one byte past the end pointer for the input slice `a`
+    if a_ptr.offset(a_len as isize) != b_ptr {
+        return Err(Error::NotAdjacent);
     }
+    // UNWRAP: both smaller than isize, can't wrap in usize.
+    // This is because in rust `usize` and `isize` are both guaranteed to have
+    // the same number of bits as a pointer [1]. As `isize` is signed, a `usize`
+    // can always store the sum of two positive `isize`.
+    // [1]: https://doc.rust-lang.org/reference/types/numeric.html#machine-dependent-integer-types
+    let new_len = a_len.checked_add(b_len).unwrap();
+    // Ensure the length is bounded. The bound is strict from the definition of `max_len`
+    // `new_len <= max_len` <=> `new_len * mem::size_of::<T>() <= isize::max_value()`
+    if !(new_len <= max_len) {
+        return Err(Error::TooLong);
+    }
+    // https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#safety
+    // * slices are adjacent (checked above)
+    // * no double-free / leak because we work on borrowed data
+    // * no use-after-free because `a` and `b` have same lifetime
+    // * the total size is smaller than `isize::MAX` bytes, as max_len is rounded down
+    Ok(slice::from_raw_parts(a_ptr, new_len))
 }
 
 /// Concatenate two adjacent string slices no matter their order.
 ///
 /// This is the same as [`concat`] except that it also concatenates
 /// `b` to `a` if `b` is in front of `a` (in which case [`concat`] errors).
+///
+/// # Safety
+///
+/// The provided slices must come from the same underlying allocation. The adjacency test can not
+/// reliably differentiate between the one-past-the-end pointer of one allocation and the start of
+/// another. However, all slices must be within a single allocation.
 ///
 /// # Examples
 ///
@@ -156,7 +182,10 @@ pub fn concat_slice<'a, T>(a: &'a [T], b: &'a [T]) -> Result<&'a [T], Error> {
 /// ```rust
 /// # use str_concat::concat_unordered;
 /// let s = "0123456789";
-/// assert_eq!("0123456", concat_unordered(&s[5..7], &s[..5]).unwrap());
+/// unsafe {
+///     // SAFETY: slices from the same str originally.
+///     assert_eq!("0123456", concat_unordered(&s[5..7], &s[..5]).unwrap());
+/// }
 /// ```
 ///
 /// Normal order:
@@ -164,11 +193,14 @@ pub fn concat_slice<'a, T>(a: &'a [T], b: &'a [T]) -> Result<&'a [T], Error> {
 /// ```rust
 /// # use str_concat::{concat_unordered, Error};
 /// let s = "0123456789";
-/// assert_eq!("0123456", concat_unordered(&s[..5], &s[5..7]).unwrap())
+/// unsafe {
+///     // SAFETY: slices from the same str originally.
+///     assert_eq!("0123456", concat_unordered(&s[..5], &s[5..7]).unwrap())
+/// }
 /// ```
 ///
 /// [`concat`]: fn.concat.html
-pub fn concat_unordered<'a>(a: &'a str, b: &'a str) -> Result<&'a str, Error> {
+pub unsafe fn concat_unordered<'a>(a: &'a str, b: &'a str) -> Result<&'a str, Error> {
     // add lengths to handle empty-string cases correctly
     let a_ptr = a.as_bytes().as_ptr() as usize;
     let a_end_ptr = a_ptr + a.len();
@@ -190,6 +222,12 @@ pub fn concat_unordered<'a>(a: &'a str, b: &'a str) -> Result<&'a str, Error> {
 /// `a` if `b` is in front of `a` (in which case of [`concat_slice`] errors).
 /// Keep in mind that slices of ZSTs will still not be concatenated.
 ///
+/// # Safety
+///
+/// The provided slices must come from the same underlying allocation. The adjacency test can not
+/// reliably differentiate between the one-past-the-end pointer of one allocation and the start of
+/// another. However, all slices must be within a single allocation.
+///
 /// # Examples
 ///
 /// Reversed order:
@@ -197,7 +235,10 @@ pub fn concat_unordered<'a>(a: &'a str, b: &'a str) -> Result<&'a str, Error> {
 /// ```rust
 /// # use str_concat::concat_slice_unordered;
 /// let s = b"0123456789";
-/// assert_eq!(b"0123456", concat_slice_unordered(&s[5..7], &s[..5]).unwrap());
+/// unsafe {
+///     // SAFETY: slices from the same bytes originally.
+///     assert_eq!(b"0123456", concat_slice_unordered(&s[5..7], &s[..5]).unwrap());
+/// }
 /// ```
 ///
 /// Normal order:
@@ -205,11 +246,14 @@ pub fn concat_unordered<'a>(a: &'a str, b: &'a str) -> Result<&'a str, Error> {
 /// ```rust
 /// # use str_concat::{concat_slice_unordered, Error};
 /// let s = b"0123456789";
-/// assert_eq!(b"0123456", concat_slice_unordered(&s[..5], &s[5..7]).unwrap())
+/// unsafe {
+///     // SAFETY: slices from the same bytes originally.
+///     assert_eq!(b"0123456", concat_slice_unordered(&s[..5], &s[5..7]).unwrap())
+/// }
 /// ```
 ///
 /// [`concat_slice`]: fn.concat_slice.html
-pub fn concat_slice_unordered<'a, T>(a: &'a [T], b: &'a [T]) -> Result<&'a [T], Error> {
+pub unsafe fn concat_slice_unordered<'a, T>(a: &'a [T], b: &'a [T]) -> Result<&'a [T], Error> {
     // add lengths to handle empty cases correctly
     let a_ptr = a.as_ptr() as usize;
     let a_end_ptr = a_ptr + a.len() * mem::size_of::<T>();
@@ -232,50 +276,64 @@ mod tests {
     #[test]
     fn simple_success() {
         let s = "0123456789";
-        assert_eq!(Ok("0123456"), concat(&s[..5], &s[5..7]));
-        assert_eq!(Ok("0123456"), concat_unordered(&s[..5], &s[5..7]));
+        unsafe {
+            assert_eq!(Ok("0123456"), concat(&s[..5], &s[5..7]));
+            assert_eq!(Ok("0123456"), concat_unordered(&s[..5], &s[5..7]));
+        }
     }
 
     #[test]
     fn unordered() {
         let s = "0123456789";
-        assert_eq!(Err(Error::NotAdjacent), concat(&s[5..7], &s[..5]));
-        assert_eq!(Ok("0123456"), concat_unordered(&s[5..7], &s[..5]));
+        unsafe {
+            assert_eq!(Err(Error::NotAdjacent), concat(&s[5..7], &s[..5]));
+            assert_eq!(Ok("0123456"), concat_unordered(&s[5..7], &s[..5]));
+        }
     }
 
     #[test]
     fn simple_fail() {
         let s = "0123456789";
-        assert_eq!(Err(Error::NotAdjacent), concat(&s[..5], &s[6..7]))
+        unsafe {
+            assert_eq!(Err(Error::NotAdjacent), concat(&s[..5], &s[6..7]))
+        }
     }
 
     #[test]
     fn zero_width_joiner() {
         let s = "0\u{200d}1";
-        assert_eq!(Ok("0\u{200d}1"), concat(&s[..1], &s[1..5]));
+        unsafe {
+            assert_eq!(Ok("0\u{200d}1"), concat(&s[..1], &s[1..5]));
+        }
     }
 
     #[test]
     fn zero_width_joiner_combining_grave() {
         let s = "0\u{200d}̀1";
-        assert_eq!(Ok("0\u{200d}\u{300}1"), concat(&s[..1], &s[1..7]));
+        unsafe {
+            assert_eq!(Ok("0\u{200d}\u{300}1"), concat(&s[..1], &s[1..7]));
+        }
     }
 
     #[test]
     fn bom() {
         let s = "0\u{FEFF}1";
-        assert_eq!(Ok("0\u{FEFF}1"), concat(&s[..1], &s[1..5]));
+        unsafe {
+            assert_eq!(Ok("0\u{FEFF}1"), concat(&s[..1], &s[1..5]));
+        }
     }
 
     #[test]
     fn empty_str() {
         let s = "0123";
-        assert_eq!(Ok("0123"), concat(&s[..0], s));
-        assert_eq!(Ok("0123"), concat_unordered(&s[..0], s));
-        assert_eq!(Ok("0123"), concat_unordered(s, &s[..0]));
-        assert_eq!(Ok("0123"), concat(s, &s[4..]));
-        assert_eq!(Ok("0123"), concat_unordered(s, &s[4..]));
-        assert_eq!(Ok("0123"), concat_unordered(&s[4..], s));
+        unsafe {
+            assert_eq!(Ok("0123"), concat(&s[..0], s));
+            assert_eq!(Ok("0123"), concat_unordered(&s[..0], s));
+            assert_eq!(Ok("0123"), concat_unordered(s, &s[..0]));
+            assert_eq!(Ok("0123"), concat(s, &s[4..]));
+            assert_eq!(Ok("0123"), concat_unordered(s, &s[4..]));
+            assert_eq!(Ok("0123"), concat_unordered(&s[4..], s));
+        }
     }
 
     #[test]
@@ -284,17 +342,19 @@ mod tests {
         struct T(usize);
 
         let s: &[T] = &[T(0), T(1), T(2), T(3)][..];
-        assert_eq!(Ok(s), concat_slice(&s[..2], &s[2..]));
-        assert_eq!(Ok(s), concat_slice_unordered(&s[..2], &s[2..]));
-        assert_eq!(Ok(s), concat_slice_unordered(&s[2..], &s[..2]));
+        unsafe {
+            assert_eq!(Ok(s), concat_slice(&s[..2], &s[2..]));
+            assert_eq!(Ok(s), concat_slice_unordered(&s[..2], &s[2..]));
+            assert_eq!(Ok(s), concat_slice_unordered(&s[2..], &s[..2]));
 
-        // One slice empty
-        assert_eq!(Ok(s), concat_slice(&s[..0], s));
-        assert_eq!(Ok(s), concat_slice_unordered(&s[..0], s));
-        assert_eq!(Ok(s), concat_slice_unordered(s, &s[..0]));
-        assert_eq!(Ok(s), concat_slice(s, &s[4..]));
-        assert_eq!(Ok(s), concat_slice_unordered(s, &s[4..]));
-        assert_eq!(Ok(s), concat_slice_unordered(&s[4..], s));
+            // One slice empty
+            assert_eq!(Ok(s), concat_slice(&s[..0], s));
+            assert_eq!(Ok(s), concat_slice_unordered(&s[..0], s));
+            assert_eq!(Ok(s), concat_slice_unordered(s, &s[..0]));
+            assert_eq!(Ok(s), concat_slice(s, &s[4..]));
+            assert_eq!(Ok(s), concat_slice_unordered(s, &s[4..]));
+            assert_eq!(Ok(s), concat_slice_unordered(&s[4..], s));
+        }
     }
 
     #[test]
@@ -303,8 +363,10 @@ mod tests {
         struct T(usize);
 
         let s: &[T] = &[T(0), T(1), T(2), T(3)][..];
-        assert_eq!(Err(Error::NotAdjacent), concat_slice(&s[..1], &s[2..]));
-        assert_eq!(Err(Error::NotAdjacent), concat_slice_unordered(&s[..1], &s[2..]));
-        assert_eq!(Err(Error::NotAdjacent), concat_slice(&s[2..], &s[..2]));
+        unsafe {
+            assert_eq!(Err(Error::NotAdjacent), concat_slice(&s[..1], &s[2..]));
+            assert_eq!(Err(Error::NotAdjacent), concat_slice_unordered(&s[..1], &s[2..]));
+            assert_eq!(Err(Error::NotAdjacent), concat_slice(&s[2..], &s[..2]));
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ pub fn concat_slice_unordered<'a, T>(a: &'a [T], b: &'a [T]) -> Result<&'a [T], 
 
 #[cfg(test)]
 mod tests {
-    use super::{concat, concat_unordered, Error};
+    use super::{concat, concat_unordered, concat_slice, concat_slice_unordered, Error};
 
     #[test]
     fn simple_success() {
@@ -276,5 +276,35 @@ mod tests {
         assert_eq!(Ok("0123"), concat(s, &s[4..]));
         assert_eq!(Ok("0123"), concat_unordered(s, &s[4..]));
         assert_eq!(Ok("0123"), concat_unordered(&s[4..], s));
+    }
+
+    #[test]
+    fn typed_slices() {
+        #[derive(Debug, PartialEq)]
+        struct T(usize);
+
+        let s: &[T] = &[T(0), T(1), T(2), T(3)][..];
+        assert_eq!(Ok(s), concat_slice(&s[..2], &s[2..]));
+        assert_eq!(Ok(s), concat_slice_unordered(&s[..2], &s[2..]));
+        assert_eq!(Ok(s), concat_slice_unordered(&s[2..], &s[..2]));
+
+        // One slice empty
+        assert_eq!(Ok(s), concat_slice(&s[..0], s));
+        assert_eq!(Ok(s), concat_slice_unordered(&s[..0], s));
+        assert_eq!(Ok(s), concat_slice_unordered(s, &s[..0]));
+        assert_eq!(Ok(s), concat_slice(s, &s[4..]));
+        assert_eq!(Ok(s), concat_slice_unordered(s, &s[4..]));
+        assert_eq!(Ok(s), concat_slice_unordered(&s[4..], s));
+    }
+
+    #[test]
+    fn typed_fail() {
+        #[derive(Debug, PartialEq)]
+        struct T(usize);
+
+        let s: &[T] = &[T(0), T(1), T(2), T(3)][..];
+        assert_eq!(Err(Error::NotAdjacent), concat_slice(&s[..1], &s[2..]));
+        assert_eq!(Err(Error::NotAdjacent), concat_slice_unordered(&s[..1], &s[2..]));
+        assert_eq!(Err(Error::NotAdjacent), concat_slice(&s[2..], &s[..2]));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,4 +382,16 @@ mod tests {
             assert_eq!(Err(Error::NotAdjacent), concat_slice(&s[2..], &s[..2]));
         }
     }
+
+    #[test]
+    fn zst_fail() {
+        #[derive(Clone, Copy, Debug, PartialEq)]
+        struct Zst;
+
+        let s: &[Zst] = &[Zst; 4];
+        unsafe {
+            assert_eq!(Err(Error::NotAdjacent), concat_slice(&s[..1], &s[1..]));
+            assert_eq!(Err(Error::NotAdjacent), concat_slice_unordered(&s[..1], &s[1..]));
+        }
+    }
 }


### PR DESCRIPTION
Chooses the very cautious option of erroring in all cases of a ZST
concatentation for now.